### PR TITLE
Make Zola installer portable, add Codex setup instructions, and include Byline metadata in feeds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -27,6 +27,19 @@ bin/setup-git-hooks
 
 That hook runs `zola check --skip-external-links` before each commit so malformed front matter and broken internal links fail locally.
 
+
+### Codex setup script
+
+If you are using Codex's **Setup script** field, use:
+
+```bash
+git submodule update --init --recursive
+./bin/install-zola.sh
+bin/setup-git-hooks
+```
+
+This ensures `zola` is available before running local checks/builds in the container.
+
 ## Common Commands
 
 ```bash

--- a/bin/install-zola.sh
+++ b/bin/install-zola.sh
@@ -1,17 +1,40 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+set -euo pipefail
 
 # Install Zola
 ZOLA_VERSION="${ZOLA_VERSION:-0.22.0}"
-echo "Installing Zola v${ZOLA_VERSION}..."
+OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+ARCH="$(uname -m)"
 
-# Download and extract Zola
-wget -q -O zola.tar.gz "https://github.com/getzola/zola/releases/download/v${ZOLA_VERSION}/zola-v${ZOLA_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+case "$ARCH" in
+  x86_64|amd64) ARCH="x86_64" ;;
+  aarch64|arm64) ARCH="aarch64" ;;
+  *)
+    echo "Unsupported architecture: $ARCH" >&2
+    exit 1
+    ;;
+esac
+
+ASSET="zola-v${ZOLA_VERSION}-${ARCH}-unknown-${OS}-gnu.tar.gz"
+URL="https://github.com/getzola/zola/releases/download/v${ZOLA_VERSION}/${ASSET}"
+INSTALL_DIR="${ZOLA_INSTALL_DIR:-$HOME/.local/bin}"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+mkdir -p "$INSTALL_DIR"
+cd "$TMP_DIR"
+
+echo "Installing Zola v${ZOLA_VERSION} for ${OS}/${ARCH}..."
+curl -fsSL "$URL" -o zola.tar.gz
 tar -xzf zola.tar.gz
 chmod +x zola
-mkdir -p /opt/buildhome/.local/bin
-mv zola /opt/buildhome/.local/bin/
-export PATH="/opt/buildhome/.local/bin:$PATH"
+mv zola "$INSTALL_DIR/zola"
 
-echo "Zola installed successfully!"
-zola --version
+if ! command -v zola >/dev/null 2>&1; then
+  echo "Zola installed to $INSTALL_DIR. Add this to your shell profile if needed:"
+  echo "  export PATH=\"$INSTALL_DIR:\$PATH\""
+  export PATH="$INSTALL_DIR:$PATH"
+fi
+
+echo "Zola installed successfully: $(zola --version)"

--- a/templates/atom.xml
+++ b/templates/atom.xml
@@ -1,11 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="{{ lang }}">
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:byline="https://bylinespec.org/1.0" xml:lang="{{ lang }}">
     <title>{{ config.title }}</title>
     <link rel="self" type="application/atom+xml" href="{{ get_url(path="atom.xml") }}"/>
     <link rel="alternate" type="text/html" href="{{ config.base_url }}"/>
     <generator uri="https://www.getzola.org/">Zola</generator>
     <updated>{{ last_updated | date(format="%+") }}</updated>
     <id>{{ get_url(path="atom.xml") }}</id>
+    <byline:contributors>
+      <byline:person id="wesbaker">
+        <byline:name>Wes Baker</byline:name>
+        <byline:url>{{ config.base_url }}</byline:url>
+        <byline:context>Software engineer sharing notes on development, leadership, and tech.</byline:context>
+      </byline:person>
+    </byline:contributors>
     {% for page in pages %}
     <entry xml:lang="{{ page.lang }}">
         <title>{{ page.title }}</title>
@@ -21,6 +28,9 @@
           <name>Unknown</name>
         </author>
         {% endfor %}
+
+        <byline:author ref="wesbaker"/>
+        <byline:perspective>personal</byline:perspective>
 
         {% if page.extra.external_url %}
         <link rel="alternate" type="text/html" href="{{ page.extra.external_url | escape }}"/>

--- a/templates/atom.xml
+++ b/templates/atom.xml
@@ -10,7 +10,7 @@
       <byline:person id="wesbaker">
         <byline:name>Wes Baker</byline:name>
         <byline:url>{{ config.base_url }}</byline:url>
-        <byline:context>Software engineer sharing notes on development, leadership, and tech.</byline:context>
+        <byline:context>Software Engineering Manager sharing notes on development, leadership, and productivity.</byline:context>
       </byline:person>
     </byline:contributors>
     {% for page in pages %}
@@ -25,7 +25,7 @@
         </author>
         {% else %}
         <author>
-          <name>Unknown</name>
+          <name>Wes Baker</name>
         </author>
         {% endfor %}
 

--- a/templates/atom.xml
+++ b/templates/atom.xml
@@ -7,10 +7,15 @@
     <updated>{{ last_updated | date(format="%+") }}</updated>
     <id>{{ get_url(path="atom.xml") }}</id>
     <byline:contributors>
-      <byline:person id="wesbaker">
+      <byline:person id="wes">
         <byline:name>Wes Baker</byline:name>
-        <byline:url>{{ config.base_url }}</byline:url>
         <byline:context>Software Engineering Manager sharing notes on development, leadership, and productivity.</byline:context>
+        <byline:url>https://wesbaker.com</byline:url>
+        <byline:profile href="https://hachyderm.io/@wesbaker" rel="mastodon"/>
+        <byline:profile href="https://bsky.app/profile/wesbaker.com" rel="bluesky"/>
+        <byline:profile href="https://github.com/wesbaker" rel="github"/>
+        <byline:now>https://wesbaker.com/now</byline:now>
+        <byline:uses>https://wesbaker.com/uses</byline:uses>
       </byline:person>
     </byline:contributors>
     {% for page in pages %}
@@ -29,7 +34,7 @@
         </author>
         {% endfor %}
 
-        <byline:author ref="wesbaker"/>
+        <byline:author ref="wes"/>
         <byline:perspective>personal</byline:perspective>
 
         {% if page.extra.external_url %}

--- a/templates/rss.xml
+++ b/templates/rss.xml
@@ -11,7 +11,7 @@
         <byline:person id="wesbaker">
           <byline:name>Wes Baker</byline:name>
           <byline:url>{{ config.base_url }}</byline:url>
-          <byline:context>Software engineer sharing notes on development, leadership, and tech.</byline:context>
+          <byline:context>Software Engineering Manager sharing notes on development, leadership, and productivity.</byline:context>
         </byline:person>
       </byline:contributors>
       <lastBuildDate>{{ last_updated | date(format="%a, %d %b %Y %H:%M:%S %z") }}</lastBuildDate>
@@ -19,7 +19,7 @@
       <item>
           <title>{{ page.title }}</title>
           <pubDate>{{ page.date | date(format="%a, %d %b %Y %H:%M:%S %z") }}</pubDate>
-          {% if page.authors %}<author>{{ page.authors[0] }}</author>{% else %}<author>Unknown</author>{% endif %}
+          {% if page.authors %}<author>{{ page.authors[0] }}</author>{% else %}<author>Wes Baker</author>{% endif %}
           <byline:author ref="wesbaker"/>
           <byline:perspective>personal</byline:perspective>
           {% if page.extra.external_url %}

--- a/templates/rss.xml
+++ b/templates/rss.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
+<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:byline="https://bylinespec.org/1.0" version="2.0">
     <channel>
       <title>{{ config.title }}</title>
       <link>{{ config.base_url }}</link>
@@ -7,12 +7,21 @@
       <generator>Zola</generator>
       <language>{{ lang }}</language>
       <atom:link href="{{ get_url(path="rss.xml") }}" rel="self" type="application/rss+xml"/>
+      <byline:contributors>
+        <byline:person id="wesbaker">
+          <byline:name>Wes Baker</byline:name>
+          <byline:url>{{ config.base_url }}</byline:url>
+          <byline:context>Software engineer sharing notes on development, leadership, and tech.</byline:context>
+        </byline:person>
+      </byline:contributors>
       <lastBuildDate>{{ last_updated | date(format="%a, %d %b %Y %H:%M:%S %z") }}</lastBuildDate>
       {% for page in pages %}
       <item>
           <title>{{ page.title }}</title>
           <pubDate>{{ page.date | date(format="%a, %d %b %Y %H:%M:%S %z") }}</pubDate>
           {% if page.authors %}<author>{{ page.authors[0] }}</author>{% else %}<author>Unknown</author>{% endif %}
+          <byline:author ref="wesbaker"/>
+          <byline:perspective>personal</byline:perspective>
           {% if page.extra.external_url %}
           <link>{{ page.extra.external_url | escape }}</link>
           <guid isPermaLink="false">{{ page.permalink | escape }}</guid>

--- a/templates/rss.xml
+++ b/templates/rss.xml
@@ -8,10 +8,15 @@
       <language>{{ lang }}</language>
       <atom:link href="{{ get_url(path="rss.xml") }}" rel="self" type="application/rss+xml"/>
       <byline:contributors>
-        <byline:person id="wesbaker">
+        <byline:person id="wes">
           <byline:name>Wes Baker</byline:name>
-          <byline:url>{{ config.base_url }}</byline:url>
           <byline:context>Software Engineering Manager sharing notes on development, leadership, and productivity.</byline:context>
+          <byline:url>https://wesbaker.com</byline:url>
+          <byline:profile href="https://hachyderm.io/@wesbaker" rel="mastodon"/>
+          <byline:profile href="https://bsky.app/profile/wesbaker.com" rel="bluesky"/>
+          <byline:profile href="https://github.com/wesbaker" rel="github"/>
+          <byline:now>https://wesbaker.com/now</byline:now>
+          <byline:uses>https://wesbaker.com/uses</byline:uses>
         </byline:person>
       </byline:contributors>
       <lastBuildDate>{{ last_updated | date(format="%a, %d %b %Y %H:%M:%S %z") }}</lastBuildDate>
@@ -20,7 +25,7 @@
           <title>{{ page.title }}</title>
           <pubDate>{{ page.date | date(format="%a, %d %b %Y %H:%M:%S %z") }}</pubDate>
           {% if page.authors %}<author>{{ page.authors[0] }}</author>{% else %}<author>Wes Baker</author>{% endif %}
-          <byline:author ref="wesbaker"/>
+          <byline:author ref="wes"/>
           <byline:perspective>personal</byline:perspective>
           {% if page.extra.external_url %}
           <link>{{ page.extra.external_url | escape }}</link>


### PR DESCRIPTION
### Motivation

- Ensure the Zola install script works reliably in different environments and in Codex container setup by detecting OS/architecture and using a temp install path.  
- Provide a recommended Codex "Setup script" snippet in the README so `zola` is available before running local checks/builds.  
- Enrich Atom and RSS feeds with Byline metadata to include contributor and author information for the site's feeds.

### Description

- Added a `Codex setup script` snippet to `README.md` with the commands `git submodule update --init --recursive`, `./bin/install-zola.sh`, and `bin/setup-git-hooks`.  
- Rewrote `bin/install-zola.sh` to use `#!/usr/bin/env bash`, `set -euo pipefail`, detect `OS` and `ARCH`, map common arch names, build the release asset name, download via `curl`, extract in a temporary directory, install to `ZOLA_INSTALL_DIR` or `~/.local/bin`, and print usage instructions if the install path is not on `PATH`; also made the script executable.  
- Updated `templates/atom.xml` and `templates/rss.xml` to declare the `byline` namespace and add a `byline:contributors` block with a `byline:person id="wesbaker"`, plus `byline:author` references and `byline:perspective` entries in each feed entry/item.

### Testing

- Executed `./bin/install-zola.sh` on Linux x86_64 which downloaded and installed Zola and returned the expected `zola --version` output.  
- Ran `zola check --skip-external-links` against the site templates to validate feed generation and internal links and the check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8cf99b67883219d0d4a96c622175e)