### PR TITLE
Enable syntax highlighting for code blocks

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Show draft posts on preview deployments; hide them on production (main).
+if [ "${CF_PAGES_BRANCH:-main}" = "main" ]; then
+  zola build
+else
+  zola build --drafts
+fi

--- a/config.toml
+++ b/config.toml
@@ -15,9 +15,10 @@ taxonomies = [{ name = "tags" }]
 generate_feeds = true
 feed_filenames = ["atom.xml", "rss.xml"]
 
-[markdown]
-# Syntax highlighting is always enabled in Zola
-# Theme can be customised by setting the `highlight_theme` variable to a theme supported by Zola
+[markdown.highlighting]
+style = "class"
+light_theme = "github-light"
+dark_theme = "github-dark"
 
 [extra]
 # Put all your custom variables here

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,5 @@
+name = "wesbaker"
+pages_build_output_dir = "public"
+
+[build]
+command = "bin/build.sh"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,5 +1,2 @@
 name = "wesbaker"
 pages_build_output_dir = "public"
-
-[build]
-command = "bin/build.sh"


### PR DESCRIPTION
## Summary

- Adds `[markdown.highlighting]` section to `config.toml` required by Zola 0.22 (which replaced the old `[markdown] highlight_code` config)
- Sets `style = "class"` so Zola outputs CSS classes instead of inline styles, enabling the Apollo theme to load its pre-built `giallo-light.css` / `giallo-dark.css` files
- Uses `light_theme = "github-light"` and `dark_theme = "github-dark"` to match the class names the Apollo theme's CSS files expect

Stacks on top of [#1239](https://github.com/wesbaker/wesbaker.com/pull/1239).

## Test plan

- [ ] `zola serve --drafts` and visit `/posts/style-guide/` — code blocks should show syntax-highlighted colors
- [ ] Verify JavaScript, TypeScript, and shell code blocks all highlight correctly
- [ ] Check light and dark mode — colors should match each theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)