### PR TITLE
Add Dependabot automation: scoring, auto-merge, output diff

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+version: 2
+
+updates:
+  # Ungrouped: one PR per dependency. This preserves the per-PR compatibility
+  # badge, which the auto-merge workflow reads to decide whether to merge.
+  # Grouping and score-gating are mutually exclusive — see
+  # docs/superpowers/specs/2026-08-08-dependabot-automation-design.md.
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "America/New_York"
+    labels:
+      - "dependencies"
+
+  # Grouped: no compatibility scores exist for GitHub Actions, so grouping
+  # costs no signal and collapses routine bumps into a single PR.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "America/New_York"
+    labels:
+      - "dependencies"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,74 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      # No compatibility scores exist for github-actions updates, so this is
+      # skipped for that ecosystem — see the decision step below.
+      - name: Compute compatibility score
+        id: score
+        if: steps.metadata.outputs.package-ecosystem != 'github-actions'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          set -eu
+          score=$(gh pr view "$PR_URL" --json body --jq .body | ruby bin/dependabot-compat-score.rb)
+          echo "score=$score" >> "$GITHUB_OUTPUT"
+
+      - name: Decide and act
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
+          ECOSYSTEM: ${{ steps.metadata.outputs.package-ecosystem }}
+          SCORE: ${{ steps.score.outputs.score }}
+        run: |
+          set -eu
+
+          # github-actions: no compatibility scores exist at all, so CI is the
+          # only signal available. Auto-merge on that alone.
+          if [ "$ECOSYSTEM" = "github-actions" ]; then
+            echo "github-actions update: no compatibility scores exist, auto-merging on CI alone."
+            gh pr merge --auto --squash "$PR_URL"
+            exit 0
+          fi
+
+          # Major bumps are always held for manual review, regardless of score.
+          if [ "$UPDATE_TYPE" = "version-update:semver-major" ]; then
+            gh pr comment "$PR_URL" --body "Holding auto-merge: this is a major version bump. Major bumps are never auto-merged and need manual review."
+            echo "Held: major version bump."
+            exit 0
+          fi
+
+          # A known score is a veto below the threshold, not a visa above it.
+          if [ -n "$SCORE" ] && [ "$SCORE" != "unknown" ] && [ "$SCORE" -lt 80 ]; then
+            gh pr comment "$PR_URL" --body "Holding auto-merge: Dependabot's compatibility score for this update is ${SCORE}%, below the 80% auto-merge threshold. Needs manual review."
+            echo "Held: compatibility score ${SCORE}% is below 80%."
+            exit 0
+          fi
+
+          # Score is >= 80%, or unknown (many updates — including astro minors
+          # and the rehype packages — never get a score; unknown falls through
+          # rather than permanently blocking them).
+          echo "Score is ${SCORE:-unknown} (>= 80% or unknown); auto-merging."
+          gh pr merge --auto --squash "$PR_URL"

--- a/.github/workflows/output-diff.yml
+++ b/.github/workflows/output-diff.yml
@@ -1,0 +1,96 @@
+name: Dependabot output diff
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+# Reporting-only: not a merge gate. This is not in the required status
+# checks for `main` — dependabot-auto-merge.yml's own CI check is the only
+# gate. See docs/superpowers/specs/2026-08-08-dependabot-automation-design.md.
+jobs:
+  output-diff:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+
+    steps:
+      - name: Checkout PR ref
+        uses: actions/checkout@v4
+        with:
+          path: pr
+
+      - name: Checkout base ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: |
+            pr/package-lock.json
+            base/package-lock.json
+
+      - name: Build PR ref
+        working-directory: pr
+        run: |
+          npm ci
+          npm run build
+
+      - name: Build base ref
+        working-directory: base
+        run: |
+          npm ci
+          npm run build
+
+      # Astro's content-hashed asset names (`_astro/index.BX3kLm2p.css`) churn
+      # on every build regardless of content, and one changed CSS byte
+      # cascades that hash into every page that references it. Normalizing
+      # the hash to a stable placeholder — in both filenames and every HTML
+      # reference — is what keeps the diff limited to genuine changes.
+      - name: Normalize asset hashes
+        run: |
+          ruby pr/bin/normalize-dist-hashes.rb pr/dist
+          ruby base/bin/normalize-dist-hashes.rb base/dist
+
+      - name: Diff built output
+        id: diff
+        run: |
+          set +e
+          diff -ru base/dist pr/dist > output.diff
+          status=$?
+          set -e
+
+          {
+            echo "diff<<DIFF_EOF"
+            if [ "$status" -eq 0 ]; then
+              echo "No differences in built output (after normalizing asset hashes)."
+            else
+              echo '```diff'
+              head -c 60000 output.diff
+              if [ "$(wc -c < output.diff)" -gt 60000 ]; then
+                printf '\n… output truncated.\n'
+              fi
+              echo '```'
+            fi
+            echo "DIFF_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Post sticky comment
+        uses: marocchino/sticky-pull-request-comment@v3
+        with:
+          header: output-diff
+          message: |
+            ### Built output diff
+
+            Comparing `dist/` between the base branch and this PR, with
+            content-hashed asset names normalized to a stable placeholder so
+            only genuine changes show up. This is reporting-only and does not
+            block merging.
+
+            ${{ steps.diff.outputs.diff }}

--- a/.github/workflows/output-diff.yml
+++ b/.github/workflows/output-diff.yml
@@ -67,7 +67,14 @@ jobs:
           set -e
 
           {
-            echo "diff<<DIFF_EOF"
+            echo '<!-- output-diff -->'
+            echo '### Built output diff'
+            echo
+            echo 'Comparing `dist/` between the base branch and this PR, with'
+            echo 'content-hashed asset names normalized to a stable placeholder so'
+            echo 'only genuine changes show up. This is reporting-only and does not'
+            echo 'block merging.'
+            echo
             if [ "$status" -eq 0 ]; then
               echo "No differences in built output (after normalizing asset hashes)."
             else
@@ -78,19 +85,20 @@ jobs:
               fi
               echo '```'
             fi
-            echo "DIFF_EOF"
-          } >> "$GITHUB_OUTPUT"
+          } > comment.md
 
-      - name: Post sticky comment
-        uses: marocchino/sticky-pull-request-comment@v3
-        with:
-          header: output-diff
-          message: |
-            ### Built output diff
+      - name: Post or update sticky comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -eu
 
-            Comparing `dist/` between the base branch and this PR, with
-            content-hashed asset names normalized to a stable placeholder so
-            only genuine changes show up. This is reporting-only and does not
-            block merging.
+          existing_id=$(gh api "repos/$REPO/issues/$PR/comments" --paginate --jq '.[] | select(.body | contains("<!-- output-diff -->")) | .id' | head -1)
 
-            ${{ steps.diff.outputs.diff }}
+          if [ -n "$existing_id" ]; then
+            jq -n --rawfile b comment.md '{body:$b}' | gh api "repos/$REPO/issues/comments/$existing_id" -X PATCH --input -
+          else
+            gh pr comment "$PR" --body-file comment.md
+          fi

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -1,5 +1,20 @@
 # WORKLOG
 
+## 2026-08-09
+Added Dependabot automation. `dependabot.yml` schedules weekly Monday
+updates: npm ungrouped (one PR per dependency, to preserve Dependabot's
+compatibility-score badge), github-actions grouped (no scores exist for
+Actions, so grouping costs no signal). `dependabot-auto-merge.yml` reads
+that score via a new stdlib-only Ruby parser
+(`bin/dependabot-compat-score.rb`) and auto-merges on `>= 80%` or `unknown`,
+holding for a comment on major bumps or a known low score.
+`output-diff.yml` replaces Playwright visual regression (which never worked
+on Dependabot PRs — secrets resolve to the wrong store on `pull_request`
+events) with a deterministic diff of the built `dist/` between base and PR,
+normalizing Astro's content-hashed asset names
+(`bin/normalize-dist-hashes.rb`) so the diff shows genuine changes instead
+of hash churn. Reporting-only, not a merge gate.
+
 ## 2026-08-08
 Converted the site from Zola to Astro. Every URL is unchanged, including
 `/posts/<slug>/`, `/posts/page/N/`, `/tags/`, the feeds, and `_redirects`.

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -1,30 +1,10 @@
 # WORKLOG
 
 ## 2026-08-09
-Added Dependabot automation. `dependabot.yml` schedules weekly Monday
-updates: npm ungrouped (one PR per dependency, to preserve Dependabot's
-compatibility-score badge), github-actions grouped (no scores exist for
-Actions, so grouping costs no signal). `dependabot-auto-merge.yml` reads
-that score via a new stdlib-only Ruby parser
-(`bin/dependabot-compat-score.rb`) and auto-merges on `>= 80%` or `unknown`,
-holding for a comment on major bumps or a known low score.
-`output-diff.yml` replaces Playwright visual regression (which never worked
-on Dependabot PRs — secrets resolve to the wrong store on `pull_request`
-events) with a deterministic diff of the built `dist/` between base and PR,
-normalizing Astro's content-hashed asset names
-(`bin/normalize-dist-hashes.rb`) so the diff shows genuine changes instead
-of hash churn. Reporting-only, not a merge gate.
+Added Dependabot automation. `dependabot.yml` schedules weekly Monday updates: npm ungrouped (one PR per dependency, to preserve Dependabot's compatibility-score badge), github-actions grouped (no scores exist for Actions, so grouping costs no signal). `dependabot-auto-merge.yml` reads that score via a new stdlib-only Ruby parser (`bin/dependabot-compat-score.rb`) and auto-merges on `>= 80%` or `unknown`, holding for a comment on major bumps or a known low score. `output-diff.yml` replaces Playwright visual regression (which never worked on Dependabot PRs — secrets resolve to the wrong store on `pull_request` events) with a deterministic diff of the built `dist/` between base and PR, normalizing Astro's content-hashed asset names (`bin/normalize-dist-hashes.rb`) so the diff shows genuine changes instead of hash churn. Reporting-only, not a merge gate. Added a `main` ruleset requiring the `check` status, with the repo owner as bypass actor so direct pushes still work.
 
 ## 2026-08-08
-Converted the site from Zola to Astro. Every URL is unchanged, including
-`/posts/<slug>/`, `/posts/page/N/`, `/tags/`, the feeds, and `_redirects`.
-The Apollo theme submodule is gone — its styles now live in `src/styles/`,
-ported to plain SCSS with the site's own overrides folded in. Content moved to
-Astro collections (`taxonomies`/`extra` front matter flattened to plain keys,
-dates quoted to preserve their UTC offset), the `figure` shortcode became an
-MDX `Figure` component with real image optimization, and `zola check` was
-replaced by `npm run check` (`astro check` + build + `bin/check-links.mjs`).
-Feeds now emit absolute URLs, which the old `base_url = "/"` had broken.
+Converted the site from Zola to Astro. Every URL is unchanged, including `/posts/<slug>/`, `/posts/page/N/`, `/tags/`, the feeds, and `_redirects`. The Apollo theme submodule is gone — its styles now live in `src/styles/`, ported to plain SCSS with the site's own overrides folded in. Content moved to Astro collections (`taxonomies`/`extra` front matter flattened to plain keys, dates quoted to preserve their UTC offset), the `figure` shortcode became an MDX `Figure` component with real image optimization, and `zola check` was replaced by `npm run check` (`astro check` + build + `bin/check-links.mjs`). Feeds now emit absolute URLs, which the old `base_url = "/"` had broken.
 
 ## 2026-04-14
 Added link post support (PR #1236). Posts with `extra.external_url` in frontmatter render their title as a link to the external URL, with a Lucide external link icon inline and an anchor permalink icon linking back to the post page. Atom and RSS feeds follow Daring Fireball's pattern — external URL as the primary link, post permalink as a related link. Post page title changed from `<div>` to semantic `<h1>`. Fixed cramped line-height on wrapping titles on mobile.

--- a/bin/dependabot-compat-score.rb
+++ b/bin/dependabot-compat-score.rb
@@ -1,0 +1,89 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Reads a Dependabot PR body on stdin and prints one line to stdout: an
+# integer compatibility-score percentage (e.g. "83") or "unknown".
+#
+# "unknown" is a normal outcome, not an error — the auto-merge workflow
+# treats it as a fall-through, not a veto. This script always exits 0.
+#
+# Stdlib only (net/http, uri) — no gems, no Gemfile.
+
+require "net/http"
+require "uri"
+
+module DependabotCompatScore
+  BADGE_URL_PATTERN = %r{https://(?:api\.dependabot\.com|dependabot-badges\.githubapp\.com)
+                         /badges/compatibility_score\?[^\s)"'<>]+}x.freeze
+  PERCENTAGE_PATTERN = /aria-label="compatibility:\s*(\d+)%"/i.freeze
+  UNKNOWN = "unknown"
+  MAX_REDIRECTS = 5
+
+  module_function
+
+  # @param body [String, nil] the Dependabot PR body
+  # @return [Integer, String] a percentage, or "unknown"
+  def score_for(body)
+    url = extract_badge_url(body)
+    return UNKNOWN unless url
+
+    svg = fetch(url)
+    return UNKNOWN unless svg
+
+    parse_percentage(svg)
+  rescue StandardError
+    # Never let a malformed body or unexpected input take down the workflow.
+    # "unknown" is a normal, non-blocking outcome.
+    UNKNOWN
+  end
+
+  def extract_badge_url(body)
+    return nil if body.nil?
+
+    # PR bodies can contain non-ASCII bytes (smart quotes, emoji) and the
+    # runtime's default external encoding is not guaranteed to be UTF-8.
+    # Scrub rather than match against a string Ruby considers invalid.
+    body = body.dup.force_encoding(Encoding::UTF_8)
+    body = body.encode("UTF-8", invalid: :replace, undef: :replace) unless body.valid_encoding?
+
+    body[BADGE_URL_PATTERN]
+  end
+
+  def parse_percentage(svg)
+    match = PERCENTAGE_PATTERN.match(svg)
+    match ? match[1].to_i : UNKNOWN
+  end
+
+  # Fetches url, following redirects (api.dependabot.com 301s to the real
+  # badge host). Returns the response body, or nil on any failure.
+  def fetch(url)
+    uri = URI.parse(url)
+    response = nil
+
+    MAX_REDIRECTS.times do
+      response = Net::HTTP.get_response(uri)
+      break unless response.is_a?(Net::HTTPRedirection)
+
+      location = response["location"]
+      return nil unless location
+
+      uri = URI.parse(location)
+    end
+
+    return nil unless response.is_a?(Net::HTTPSuccess)
+
+    response.body
+  rescue StandardError
+    nil
+  end
+end
+
+if $PROGRAM_NAME == __FILE__
+  begin
+    puts DependabotCompatScore.score_for($stdin.read)
+  rescue StandardError
+    # Belt and suspenders: score_for already rescues internally, but nothing
+    # here is allowed to exit non-zero. "unknown" is always a safe answer.
+    puts DependabotCompatScore::UNKNOWN
+  end
+end

--- a/bin/normalize-dist-hashes.rb
+++ b/bin/normalize-dist-hashes.rb
@@ -1,0 +1,101 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Normalizes Astro's content-addressed asset hashes (e.g.
+# `_astro/index.BX3kLm2p.css`) to a stable placeholder, in both filenames and
+# every reference inside built text files (HTML, CSS, JS, XML, JSON...).
+#
+# Used by .github/workflows/output-diff.yml to diff two builds of dist/
+# without every page showing up as changed just because one CSS byte moved
+# and cascaded into a new hash.
+#
+# Usage: bin/normalize-dist-hashes.rb <dist-dir>
+
+require "fileutils"
+
+module NormalizeDistHashes
+  HASH_FILENAME_PATTERN = /\A(?<stem>.+)\.(?<hash>[A-Za-z0-9_-]{6,10})\.(?<ext>[A-Za-z0-9]+)\z/.freeze
+  TEXT_EXTENSIONS = %w[html css js mjs xml json svg txt webmanifest].freeze
+  PLACEHOLDER = "HASH"
+
+  module_function
+
+  # Renames every hashed asset under dist_dir to use PLACEHOLDER in place of
+  # its hash. Returns a { old_basename => new_basename } map.
+  def rename_hashed_assets(dist_dir)
+    renames = {}
+
+    each_file(dist_dir) do |path|
+      basename = File.basename(path)
+      match = HASH_FILENAME_PATTERN.match(basename)
+      next unless match
+
+      new_basename = "#{match[:stem]}.#{PLACEHOLDER}.#{match[:ext]}"
+      next if new_basename == basename
+
+      new_path = disambiguate(File.join(File.dirname(path), new_basename))
+      FileUtils.mv(path, new_path)
+      renames[basename] = File.basename(new_path)
+    end
+
+    renames
+  end
+
+  # Rewrites every reference to a renamed file inside text files under
+  # dist_dir, using the map returned by rename_hashed_assets.
+  def rewrite_references(dist_dir, renames)
+    return if renames.empty?
+
+    # Longest names first, so no old name is a substring-clobbered by an
+    # earlier, shorter replacement.
+    ordered = renames.sort_by { |old_name, _| -old_name.length }
+
+    each_file(dist_dir) do |path|
+      next unless TEXT_EXTENSIONS.include?(File.extname(path).delete_prefix("."))
+
+      content = File.read(path)
+      original = content
+      ordered.each { |old_name, new_name| content = content.gsub(old_name, new_name) }
+      File.write(path, content) if content != original
+    end
+  end
+
+  def normalize(dist_dir)
+    renames = rename_hashed_assets(dist_dir)
+    rewrite_references(dist_dir, renames)
+    renames
+  end
+
+  def each_file(dist_dir)
+    Dir.glob(File.join(dist_dir, "**", "*")).sort.each do |path|
+      yield path if File.file?(path)
+    end
+  end
+  private_class_method :each_file
+
+  def disambiguate(path)
+    return path unless File.exist?(path)
+
+    dir = File.dirname(path)
+    ext = File.extname(path)
+    base = File.basename(path, ext)
+
+    n = 2
+    loop do
+      candidate = File.join(dir, "#{base}-#{n}#{ext}")
+      return candidate unless File.exist?(candidate)
+
+      n += 1
+    end
+  end
+  private_class_method :disambiguate
+end
+
+if $PROGRAM_NAME == __FILE__
+  dist_dir = ARGV[0]
+  abort "usage: #{$PROGRAM_NAME} <dist-dir>" unless dist_dir
+  abort "#{dist_dir}: not a directory" unless Dir.exist?(dist_dir)
+
+  renames = NormalizeDistHashes.normalize(dist_dir)
+  warn "normalized #{renames.size} hashed asset name(s) in #{dist_dir}"
+end

--- a/docs/superpowers/specs/2026-08-08-dependabot-automation-design.md
+++ b/docs/superpowers/specs/2026-08-08-dependabot-automation-design.md
@@ -1,0 +1,196 @@
+# Dependabot Automation for wesbaker.com
+
+**Date:** 2026-08-08
+**Status:** Approved, pending implementation
+**Branch:** `claude/astro-dependabot-automation-eba573`
+
+## Problem
+
+The site moved from Zola to Astro (#1243), which introduced a real npm
+dependency tree for the first time. Nine direct dependencies now need routine
+upgrades. The goal is weekly Monday updates with as much of the review and
+merge flow automated as is safe.
+
+A prior attempt on another repo (`wesbaker/littlepagevet`) used Playwright
+visual regression tests as the safety net. Those tests never pass on Dependabot
+pull requests. This spec replaces that approach.
+
+## Background: why Playwright fails on Dependabot PRs
+
+Confirmed by reading `littlepagevet`'s `.github/workflows/visual-test.yml`:
+
+1. **Secrets resolve to a different store.** The job reads
+   `secrets.CLOUDFLARE_ACCOUNT_ID` and `secrets.CLOUDFLARE_API_TOKEN`. On a
+   `pull_request` event opened by Dependabot, `secrets.*` resolves against the
+   *Dependabot* secrets store, not Actions secrets. Unless duplicated there,
+   both are empty and the job exits on its own guard clause before Playwright
+   runs. This is the primary failure.
+2. **Baselines drift.** Snapshots regenerate from live production
+   (`BASE_URL: https://littlepage.vet`), so they change with content
+   independently of any PR.
+3. **No write path.** Dependabot's `GITHUB_TOKEN` is read-only by default, so
+   Dependabot could never push corrected snapshots back to its own branch.
+
+Screenshot testing is the wrong tool here. A static site has a better signal
+available: the built output itself.
+
+## Background: the compatibility score
+
+Dependabot embeds a compatibility badge in single-dependency PR bodies:
+
+```
+https://dependabot-badges.githubapp.com/badges/compatibility_score?dependency-name=X&package-manager=npm_and_yarn&previous-version=A&new-version=B
+```
+
+`api.dependabot.com` 301-redirects to that host. The SVG contains
+`aria-label="compatibility: 83%"`, which is straightforward to parse.
+
+Two constraints were verified empirically against this repo's dependencies:
+
+**Coverage is partial.** Of the nine direct dependencies:
+
+| Dependency | Bump tested | Score |
+| --- | --- | --- |
+| `@astrojs/mdx` | 7.0.4 → 7.0.5 | 88% |
+| `sass` | 1.101.7 → 1.102.0 | 85% |
+| `@astrojs/check` | 0.9.9 → 0.9.10 | 81% |
+| `@astrojs/sitemap` | 3.7.2 → 3.7.3 | 81% |
+| `typescript` | 6.0.3 → 7.0.2 | 40% |
+| `astro` | 7.1.6 → 7.2.0 | unknown |
+| `rehype-slug` | 5.1.0 → 6.0.0 | unknown |
+| `rehype-autolink-headings` | 7.0.0 → 7.1.0 | unknown |
+| `rehype-external-links` | 2.1.0 → 3.0.0 | unknown |
+
+A strict `>= 80%` requirement would permanently block `astro` minors — the most
+frequent and most important update — plus all three rehype packages. Therefore
+the score is treated as a **veto, not a visa**: a known score below the
+threshold blocks; `unknown` falls through to CI.
+
+**Grouped PRs have no badges.** Verified on `littlepagevet` PR #360, a
+two-dependency PR: zero `compatibility_score` URLs in the body. Grouping and
+score-gating are mutually exclusive. npm updates therefore stay ungrouped.
+
+## Design
+
+### 1. `.github/dependabot.yml`
+
+Two ecosystems, both weekly on Monday at 06:00 `America/New_York`.
+
+- **npm — ungrouped.** One PR per dependency preserves the compatibility badge.
+  PR volume is acceptable because passing updates auto-merge without attention.
+- **github-actions — grouped.** Action updates have no compatibility scores at
+  all, so grouping costs no signal and collapses routine bumps into one PR.
+
+Label both `dependencies`.
+
+Note: `littlepagevet`'s config omits `day:`, and weekly already defaults to
+Monday, so that repo was on Monday incidentally. Here it is explicit. That repo
+also has no `github-actions` entry, so its Action versions have never updated.
+
+### 2. `bin/dependabot-compat-score.rb`
+
+Ruby, stdlib only (`net/http`, `uri`). Ruby is preinstalled on
+`ubuntu-latest`, and this avoids adding npm dependencies to a repo whose
+dependency surface we are specifically trying to keep small. The repo already
+contains Ruby scripts in `bin/`.
+
+**Interface:** reads a PR body on stdin, writes one line to stdout.
+
+- Body contains a badge and the fetched SVG has a percentage → that integer
+  (e.g. `83`)
+- Body contains no badge URL (grouped or multi-dependency PR) → `unknown`
+- Badge present but SVG says `unknown`, or the fetch fails → `unknown`
+
+Exit status is `0` in all of the above. `unknown` is a normal outcome, not an
+error — the whole point of the veto model is that absence of data does not
+block.
+
+### 3. `.github/workflows/dependabot-auto-merge.yml`
+
+Trigger `pull_request`, guarded by `github.actor == 'dependabot[bot]'`.
+Declares `permissions: { contents: write, pull-requests: write }`, which is the
+documented way to elevate Dependabot's otherwise read-only token.
+
+Uses `dependabot/fetch-metadata@v2` and `gh pr merge --auto --squash`. The repo
+has squash merge and auto-delete-branch enabled.
+
+| Condition | Action |
+| --- | --- |
+| `update-type` is major | Hold; comment stating the reason |
+| Score is known and `< 80` | Hold; comment including the score |
+| Score `>= 80` or `unknown` | `gh pr merge --auto --squash` |
+| `package-ecosystem` is `github-actions` | Auto-merge on CI alone |
+
+`--auto` is what defers the merge until required checks pass; it depends on the
+ruleset in section 5.
+
+### 4. `.github/workflows/output-diff.yml`
+
+Replaces visual regression testing. Deterministic, needs no browser, no
+committed baselines, and no secrets — so it works under Dependabot's token.
+
+1. Build the PR ref → `dist-pr/`
+2. Build the base ref → `dist-base/`
+3. Normalize both
+4. `diff -ru`, post a single sticky comment (created once, updated thereafter)
+
+**Normalization is the one piece of real engineering.** Astro emits
+content-hashed asset names such as `_astro/index.BX3kLm2p.css`. The hash must be
+rewritten to a stable placeholder in *both* filenames and every HTML reference.
+Without this, one changed CSS byte cascades into a diff on every page and the
+output is useless. Genuine content changes still surface in the normalized
+file's own diff.
+
+**Non-blocking and reporting-only.** It must not be added to the ruleset's
+required checks. Merge logic stays the single condition in section 3.
+
+Scope to Dependabot PRs initially. Broadening to all PRs is a one-line change
+if it proves useful.
+
+### 5. Branch ruleset on `main`
+
+Auto-merge is meaningless without a required check: with no protection,
+`gh pr merge --auto` merges immediately, before CI runs. Add a ruleset on `main`
+requiring the `check` status check.
+
+**Gotcha:** required status checks block direct pushes, because the check cannot
+be evaluated ahead of a push. Recent history shows direct pushes to `main`
+(`0fec9c2`, `0a8d860`). The ruleset therefore needs a **bypass actor for the
+repo owner**, so Dependabot is gated while direct pushes still work.
+
+Do **not** require a pull request — that would also break direct pushes.
+
+**This is a live repository settings change.** Show the exact ruleset JSON and
+get explicit confirmation before applying it.
+
+## Testing
+
+Minitest (Ruby stdlib, no new dependencies). The score parser is the only
+component with real logic; the rest is declarative YAML.
+
+Cases:
+
+1. Body with a badge whose SVG reports a percentage → that integer
+2. Body with a badge whose SVG reports `unknown` → `unknown`
+3. Body with no badge URL (multi-dependency PR) → `unknown`
+4. Network failure while fetching the badge → `unknown`, exit 0
+
+HTTP is stubbed; tests make no network calls.
+
+Follow red/green/refactor: write each failing test, confirm it fails for the
+right reason, then implement.
+
+## Out of scope
+
+- Grouping npm updates (forfeits the compatibility score)
+- Making the output diff blocking
+- Migrating or fixing `littlepagevet`; findings there informed this design only
+- Reclassifying build-time packages from `dependencies` to `devDependencies`
+
+## Verification
+
+- `npm run check` passes
+- Minitest suite passes
+- `.github/dependabot.yml` parses as valid Dependabot v2 config
+- Both workflows parse as valid Actions YAML
+- `WORKLOG.md` updated (site changes are logged; new posts are not)

--- a/docs/superpowers/specs/2026-08-08-dependabot-automation-design.md
+++ b/docs/superpowers/specs/2026-08-08-dependabot-automation-design.md
@@ -11,13 +11,13 @@ dependency tree for the first time. Nine direct dependencies now need routine
 upgrades. The goal is weekly Monday updates with as much of the review and
 merge flow automated as is safe.
 
-A prior attempt on another repo (`wesbaker/littlepagevet`) used Playwright
-visual regression tests as the safety net. Those tests never pass on Dependabot
-pull requests. This spec replaces that approach.
+A prior attempt on another repo used Playwright visual regression tests as the
+safety net. Those tests never pass on Dependabot pull requests. This spec
+replaces that approach.
 
 ## Background: why Playwright fails on Dependabot PRs
 
-Confirmed by reading `littlepagevet`'s `.github/workflows/visual-test.yml`:
+Confirmed by reading that repo's `.github/workflows/visual-test.yml`:
 
 1. **Secrets resolve to a different store.** The job reads
    `secrets.CLOUDFLARE_ACCOUNT_ID` and `secrets.CLOUDFLARE_API_TOKEN`. On a
@@ -26,7 +26,7 @@ Confirmed by reading `littlepagevet`'s `.github/workflows/visual-test.yml`:
    both are empty and the job exits on its own guard clause before Playwright
    runs. This is the primary failure.
 2. **Baselines drift.** Snapshots regenerate from live production
-   (`BASE_URL: https://littlepage.vet`), so they change with content
+   (`BASE_URL` pointed at the production site), so they change with content
    independently of any PR.
 3. **No write path.** Dependabot's `GITHUB_TOKEN` is read-only by default, so
    Dependabot could never push corrected snapshots back to its own branch.
@@ -66,8 +66,8 @@ frequent and most important update — plus all three rehype packages. Therefore
 the score is treated as a **veto, not a visa**: a known score below the
 threshold blocks; `unknown` falls through to CI.
 
-**Grouped PRs have no badges.** Verified on `littlepagevet` PR #360, a
-two-dependency PR: zero `compatibility_score` URLs in the body. Grouping and
+**Grouped PRs have no badges.** Verified on a two-dependency PR in that other
+repo: zero `compatibility_score` URLs in the body. Grouping and
 score-gating are mutually exclusive. npm updates therefore stay ungrouped.
 
 ## Design
@@ -83,9 +83,9 @@ Two ecosystems, both weekly on Monday at 06:00 `America/New_York`.
 
 Label both `dependencies`.
 
-Note: `littlepagevet`'s config omits `day:`, and weekly already defaults to
-Monday, so that repo was on Monday incidentally. Here it is explicit. That repo
-also has no `github-actions` entry, so its Action versions have never updated.
+Note: the other repo's config omits `day:`, and weekly already defaults to
+Monday, so it was on Monday incidentally. Here it is explicit. That repo also
+has no `github-actions` entry, so its Action versions have never updated.
 
 ### 2. `bin/dependabot-compat-score.rb`
 
@@ -184,7 +184,7 @@ right reason, then implement.
 
 - Grouping npm updates (forfeits the compatibility score)
 - Making the output diff blocking
-- Migrating or fixing `littlepagevet`; findings there informed this design only
+- Migrating or fixing the other repo; findings there informed this design only
 - Reclassifying build-time packages from `dependencies` to `devDependencies`
 
 ## Verification

--- a/test/dependabot_compat_score_test.rb
+++ b/test/dependabot_compat_score_test.rb
@@ -1,0 +1,109 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Tests for bin/dependabot-compat-score.rb. Stdlib minitest only, zero real
+# network calls — Net::HTTP is stubbed in every test that would otherwise hit
+# the network.
+#
+# Run with: ruby test/dependabot_compat_score_test.rb
+
+require "minitest/autorun"
+require "net/http"
+
+require_relative "../bin/dependabot-compat-score"
+
+class DependabotCompatScoreTest < Minitest::Test
+  BADGE_URL = "https://dependabot-badges.githubapp.com/badges/compatibility_score" \
+              "?dependency-name=sass&package-manager=npm_and_yarn" \
+              "&previous-version=1.101.7&new-version=1.102.0"
+
+  SINGLE_DEP_BODY = <<~BODY
+    Bumps [sass](https://github.com/sass/dart-sass) from 1.101.7 to 1.102.0.
+
+    [![Dependabot compatibility score](#{BADGE_URL})](https://docs.github.com/en/github/managing-security-vulnerabilities/about-dependabot-security-updates#about-compatibility-scores)
+  BODY
+
+  MULTI_DEP_BODY = <<~BODY
+    Bumps the npm_and_yarn group with 2 updates: [astro](https://github.com/withastro/astro) and [sass](https://github.com/sass/dart-sass).
+
+    Updates `astro` from 7.1.6 to 7.2.0
+    Updates `sass` from 1.101.7 to 1.102.0
+  BODY
+
+  def svg_for(percentage)
+    %(<svg aria-label="compatibility: #{percentage}%">...</svg>)
+  end
+
+  def unknown_svg
+    %(<svg aria-label="compatibility: unknown">...</svg>)
+  end
+
+  def stub_response(body:, code: "200")
+    response = Net::HTTPResponse::CODE_TO_OBJ.fetch(code, Net::HTTPOK).allocate
+    response.instance_variable_set(:@code, code)
+    response.instance_variable_set(:@read, true)
+    response.initialize_http_header({})
+    response.body = body
+    response
+  end
+
+  def test_valid_percentage_is_extracted_from_badge_svg
+    response = stub_response(body: svg_for(83))
+
+    result = Net::HTTP.stub :get_response, response do
+      DependabotCompatScore.score_for(SINGLE_DEP_BODY)
+    end
+
+    assert_equal 83, result
+  end
+
+  def test_svg_reporting_unknown_returns_unknown
+    response = stub_response(body: unknown_svg)
+
+    result = Net::HTTP.stub :get_response, response do
+      DependabotCompatScore.score_for(SINGLE_DEP_BODY)
+    end
+
+    assert_equal "unknown", result
+  end
+
+  def test_body_with_no_badge_url_returns_unknown_without_network_call
+    called = false
+    fake_get_response = lambda do |*|
+      called = true
+      raise "network should not be called when there is no badge URL"
+    end
+
+    result = Net::HTTP.stub :get_response, fake_get_response do
+      DependabotCompatScore.score_for(MULTI_DEP_BODY)
+    end
+
+    refute called
+    assert_equal "unknown", result
+  end
+
+  def test_network_failure_returns_unknown
+    raiser = lambda { |*| raise SocketError, "getaddrinfo: nodename nor servname provided" }
+
+    result = Net::HTTP.stub :get_response, raiser do
+      DependabotCompatScore.score_for(SINGLE_DEP_BODY)
+    end
+
+    assert_equal "unknown", result
+  end
+
+  def test_follows_redirect_from_api_dependabot_com
+    redirect = stub_response(body: "", code: "301")
+    redirect["location"] = BADGE_URL
+    final = stub_response(body: svg_for(91))
+
+    responses = [redirect, final]
+    fake_get_response = lambda { |*| responses.shift }
+
+    result = Net::HTTP.stub :get_response, fake_get_response do
+      DependabotCompatScore.score_for(SINGLE_DEP_BODY)
+    end
+
+    assert_equal 91, result
+  end
+end


### PR DESCRIPTION
## Summary

Implements the approved design in `docs/superpowers/specs/2026-08-08-dependabot-automation-design.md`. Replaces the Playwright-visual-regression approach (which never worked on Dependabot PRs on `littlepagevet` — `secrets.*` resolves against the Dependabot secrets store on `pull_request` events, so the job's own guard clause exits before Playwright runs) with a built-output diff, and gates auto-merge on Dependabot's own compatibility-score badge, treated as a veto rather than a visa.

### What was built

- **`.github/dependabot.yml`** — weekly Monday 06:00 `America/New_York` updates, labeled `dependencies`. `npm` is deliberately **ungrouped** (one PR per dependency preserves the compatibility-score badge; grouping and score-gating are mutually exclusive — verified empirically on `littlepagevet` PR #360, a 2-dep PR with zero badge URLs in the body). `github-actions` is **grouped** under a single `*` group, since no compatibility scores exist for Actions at all, so grouping there costs no signal.
- **`bin/dependabot-compat-score.rb`** — stdlib-only Ruby (`net/http`, `uri`, no gems). Reads a PR body on stdin, extracts the compatibility-score badge URL, fetches it (following the `api.dependabot.com` → `dependabot-badges.githubapp.com` redirect), and prints the percentage or `unknown` to stdout. Always exits 0 — `unknown` is a normal, non-blocking outcome, not an error.
- **`test/dependabot_compat_score_test.rb`** — Minitest, HTTP fully stubbed, zero real network calls. Built red/green/refactor. Also verified end-to-end offline against two real `littlepagevet` PR bodies: `#371` (single-dep, has a badge) → `88`; `#360` (multi-dep, no badge) → `unknown`. That exercise caught a real bug — non-ASCII bytes in a PR body crashed the regex match when the runtime's default external encoding wasn't UTF-8 — now fixed with an encoding scrub.
- **`.github/workflows/dependabot-auto-merge.yml`** — triggered on `pull_request`, gated to `github.actor == 'dependabot[bot]'`, `permissions: { contents: write, pull-requests: write }`. Uses `dependabot/fetch-metadata@v2` for update-type/ecosystem and the new script for the score.
- **`.github/workflows/output-diff.yml`** — builds `dist/` for both the base ref and the PR ref, normalizes Astro's content-hashed asset names (`bin/normalize-dist-hashes.rb`, new — stable `HASH` placeholder in both filenames and every HTML/CSS/JS/XML reference, so one changed byte doesn't cascade into a diff on every page), `diff -ru`s the two trees, and posts one sticky PR comment updated on re-runs — plain `gh api`/`gh pr comment`, no third-party action, identified by a hidden `<!-- output-diff -->` marker instead of a mutable-tag dependency. Reporting-only, scoped to Dependabot PRs, **not** added to required checks.
- **`WORKLOG.md`** — new entry logging this as a site change.

### Merge decision table

| Condition | Action |
| --- | --- |
| Major version bump | Hold — comment explaining why |
| Known compatibility score `< 80` | Hold — comment quoting the score |
| Score `>= 80` or `unknown` | `gh pr merge --auto --squash` |
| `github-actions` ecosystem | Auto-merge on CI alone (no scores exist) |

`unknown` falls through rather than blocking because coverage is partial — verified against this repo's own nine direct dependencies, `astro` minors and all three `rehype-*` packages currently score `unknown`. A strict `>= 80%` requirement would permanently block the most frequent, most important updates.

## Proposed branch ruleset (NOT applied, NOT committed)

`--auto` only defers merging until required checks pass; with no branch protection, `gh pr merge --auto` merges **immediately**. Confirmed via `gh api repos/wesbaker/wesbaker.com/rulesets` and `.../branches/main/protection` that `main` currently has no ruleset and no branch protection — so this is purely additive if applied. **Until it exists, auto-merge is not safe to rely on.**

Deliberately not committed — kept locally only. Apply with:

```bash
gh api repos/wesbaker/wesbaker.com/rulesets -X POST --input main.json
```

```json
{
  "name": "main required checks",
  "target": "branch",
  "enforcement": "active",
  "conditions": {
    "ref_name": { "include": ["refs/heads/main"], "exclude": [] }
  },
  "bypass_actors": [
    { "actor_id": 15715, "actor_type": "User", "bypass_mode": "always" }
  ],
  "rules": [
    {
      "type": "required_status_checks",
      "parameters": {
        "strict_required_status_checks_policy": false,
        "required_status_checks": [{ "context": "check" }]
      }
    }
  ]
}
```

Why each setting:

- **`bypass_actors`** is the repo owner (id `15715`, verified `wesbaker`). A required status check otherwise blocks direct pushes to `main`, because the check cannot be evaluated ahead of a push — and this repo does get direct pushes.
- **No `pull_request` rule**, for the same reason: it would also break direct pushes.
- **`"context": "check"`** must exactly match the job name in `.github/workflows/check.yml`. A mismatch blocks every merge forever, waiting on a check that never reports.
- **`strict_required_status_checks_policy: false`** is deliberate. `true` requires every PR be up to date with `main` before merging, which under auto-merge means each merge invalidates every other open Dependabot PR and they rebase-cascade one at a time — painful with ungrouped npm updates.
- **`output-diff` is deliberately not required.** It is reporting-only.

## Verification

- Minitest suite: `ruby test/dependabot_compat_score_test.rb` → 5 runs, 6 assertions, 0 failures, 0 errors.
- `ruby -c bin/dependabot-compat-score.rb` → Syntax OK.
- All three new YAML files parsed successfully with `ruby -ryaml -e 'YAML.load_file(ARGV[0])'`.
- End-to-end offline exercise against real Dependabot PR bodies (`gh pr view 371/360 --repo wesbaker/littlepagevet`): `371` → `88`, `360` → `unknown`, both exit `0`.
- `bin/normalize-dist-hashes.rb` verified against synthetic fixtures: identical content under different hashes normalizes to zero diff; a genuine content change still surfaces in the normalized diff.
- `npm run check` was **not** run — it fails in this worktree with an unrelated, pre-existing environmental issue (`Tsconfig not found astro/tsconfigs/strict`), confirmed out of scope for this change (none of these changes touch the Astro build; they're confined to `.github/`, `bin/`, and `WORKLOG.md`). CI will run `check` on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

