### PR TITLE
Fix output-diff sticky comment posting outside a git checkout

### DIFF
--- a/.github/workflows/output-diff.yml
+++ b/.github/workflows/output-diff.yml
@@ -100,5 +100,5 @@ jobs:
           if [ -n "$existing_id" ]; then
             jq -n --rawfile b comment.md '{body:$b}' | gh api "repos/$REPO/issues/comments/$existing_id" -X PATCH --input -
           else
-            gh pr comment "$PR" --body-file comment.md
+            gh pr comment "$PR" --repo "$REPO" --body-file comment.md
           fi


### PR DESCRIPTION
## Summary
- `output-diff.yml` checks out the PR/base refs into `pr/` and `base/` subdirectories, so the workspace root is never a git checkout.
- The comment-posting step's create path (`gh pr comment "$PR" --body-file comment.md`) has no `--repo` flag, so `gh` tries to infer the repo from git in the current directory and fails with `fatal: not a git repository`.
- Surfaced on #1246, apparently the first Dependabot PR whose `output-diff` job ran to completion (earlier runs are stuck `pending`).
- Fix: pass `--repo "$REPO"` explicitly, same as the update path already does via the fully-qualified `gh api` call.

## Test plan
- [x] `npm run check` passes locally (pre-commit hook)
- [ ] Confirm `output-diff` job succeeds on a real Dependabot-triggered PR after this merges (job is gated on `github.actor == 'dependabot[bot]'`, so it can't be exercised by a manual push)